### PR TITLE
Use SHA256 ChecksumAlgorithm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Running BinSkim on OpenVsixSignTool.Core.dll in https://www.nuget.org/packages/OpenVsixSignTool.Core/0.3.2 I get:

> warning BA2004: 'OpenVsixSignTool.Core.dll' is a managed binary compiled with an insecure (SHA-1) source code hashing algorithm. SHA-1 is subject to collision attacks and its use can compromise supply chain integrity. Pass '-checksumalgorithm:SHA256' on the csc.exe command-line or populate the project <ChecksumAlgorithm> property with 'SHA256' to enable secure source code hashing.

`ChecksumAlgorithm` "[controls the checksum algorithm we use to encode source files in the PDB.](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/advanced#checksumalgorithm)"

This change switches from SHA1 (default) to SHA256 for more secure PDB files.